### PR TITLE
MOSDDBLK: always reserve 2 drives for floppies [fixes #21]

### DIFF
--- a/SOURCES/src/kernel/MOSDDINT.ASM
+++ b/SOURCES/src/kernel/MOSDDINT.ASM
@@ -582,6 +582,8 @@ ddinit0 proc near
 	pop	bx
 	mov	es:[bx+10],dl		; number of drives actually installed
 	add	[scbdrivs],dl		; increasing total number of drives in system
+	jnz	ddi0b
+	add	[scbdrivs],2		; if no floppy installed, reserve A and B
 	jmp	ddi0b
 ddi0a:
 	call	moscdint		; character device (look for standard devices)


### PR DESCRIPTION
This is a quick-fix that prevents HDD from moving to A:.
It is not clear why HDD does not work on A:, maybe it should?
Maybe someone else can code up the more intrusive fix.