### PR TITLE
make number of reserved drives controlable

### DIFF
--- a/SOURCES/src/kernel/MOSDDINT.ASM
+++ b/SOURCES/src/kernel/MOSDDINT.ASM
@@ -581,9 +581,13 @@ ddinit0 proc near
 	pop	es
 	pop	bx
 	mov	es:[bx+10],dl		; number of drives actually installed
+	cmp	[scbdevs],0		; see if assigning floppies
+	jne	ddi02
+	mov	[scbflops],dl		; save number of floppies installed
+	mov	dl,scbhddboot		; reserve drives up to boot HDD
+ddi02:
+	inc	[scbdevs]
 	add	[scbdrivs],dl		; increasing total number of drives in system
-	jnz	ddi0b
-	add	[scbdrivs],2		; if no floppy installed, reserve A and B
 	jmp	ddi0b
 ddi0a:
 	call	moscdint		; character device (look for standard devices)

--- a/SOURCES/src/kernel/MOSINIT2.ASM
+++ b/SOURCES/src/kernel/MOSINIT2.ASM
@@ -3448,7 +3448,7 @@ notvna:
 ; partition #)
 
 	and	al,7fh			; set mos drive id
-	add	al,2			; start hard drives at c
+	add	al,scbhddboot		; start hard drives at c
 	push	es
 	push	ax
 	int	12h			; get memory size
@@ -4092,6 +4092,8 @@ no286a:
 	mov	[tcbcdbpc],0		; clear pointer to cdb
 	mov	[tcbndriv],0		; clear # of drives
 	mov	[scbdrivs],0		; clear any count of drives for re-init
+	mov	[scbflops],0		; clear any count of drives for re-init
+	mov	[scbdevs],0		; clear any count of drives for re-init
 	mov	[scbbdbpf],0		; clear pointer to 1st block device
 	mov	[scbbdbpl],0		; clear pointer to last block device
 	mov	[scbgfbpf],0		; clear any active gfbs

--- a/SOURCES/src/kernel/MOSSCBDF.INC
+++ b/SOURCES/src/kernel/MOSSCBDF.INC
@@ -114,7 +114,7 @@ public scblastw1, scblastw2, scbrdriv, scbirqd0a, scbirqd0b, scbirqd0c
 public scbirqd0d, scbirqd0e, scbirqd0f, scbinit, scbirqbnk, SCBSAVE, scbcon417
 public scbkbrate, scbout60, scbin60, scbmconly, scbi15off, scbnorst
 public scbpost, SCB_COM_owner, SCB_COM_timeout, scbdrtcb, scbnoi5
-public scbvdrflg, scbdopflg, scbdosver
+public scbvdrflg, scbdopflg, scbdosver, scbflops, scbdevs, scbhddboot
 
 scbtcbpf	dw	0	;* pointer to first task control block
 scbtcbpl	dw	0	;* pointer to last tcb
@@ -482,6 +482,9 @@ scbreg32	db	0	; flag to indicate 32 register support, 386/486
 		dw	7500h
 		dw	0bc31h
 
-scbfill		db	31 dup(0)	; carve new variables from this allocated space
+scbflops	db	0	; # active floppy units
+scbhddboot	equ	2	; start hdd from c or above
+scbdevs		db	0	; # active block devices
+scbfill		db	29 dup(0)	; carve new variables from this allocated space
 scblen		equ	$-scb		;*
 

--- a/SOURCES/src/kernel/MOSSCBEX.INC
+++ b/SOURCES/src/kernel/MOSSCBEX.INC
@@ -57,6 +57,9 @@ extrn scbcursz:word	; mosheman usage
 extrn scbcurad:word	; mosheman usage
 extrn scbavsiz:word	; mosheman usage
 extrn scbdrivs:byte	; # active drive units
+extrn scbflops:byte	; # active floppy units
+extrn scbdevs:byte	; # active block devices
+extrn scbhddboot:abs	; start hdd from this number or more
 extrn scbnoswt:byte	; mos no switch flag
 extrn scbtskfg:byte	; task selection flags
 extrn scbdrvr:dword	; -> first device driver in list


### PR DESCRIPTION
This patch extends e543c1f3 to allow any amount of reserved
drive. Boot drive is calculated accordingly.