### PR TITLE
Updated ulib for build under bcc or tcc

### DIFF
--- a/SOURCES/src/ulib/GENNDX.BAT
+++ b/SOURCES/src/ulib/GENNDX.BAT
@@ -1,4 +1,3 @@
-if exist ulib.ndx del ulib.ndx
-extract #ulib.dat /d=ulib.ndx /b /l /m=f /s /c
+rem if exist ulib.ndx del ulib.ndx
+rem extract #ulib.dat /d=ulib.ndx /b /l /m=f /s /c
 
-

--- a/SOURCES/src/ulib/GENULIB.BAT
+++ b/SOURCES/src/ulib/GENULIB.BAT
@@ -1,3 +1,2 @@
-tcmake -fulib -Dcdir=c:\cutils
+make -fulib -Dcdir=c:\sources\src\cutils -Dccomp=%1
 
-

--- a/SOURCES/src/ulib/TESTCOMP.BAT
+++ b/SOURCES/src/ulib/TESTCOMP.BAT
@@ -1,0 +1,54 @@
+rem This script doesn't work correctly with DOSBox
+rem but it does work correctly with DOS
+@echo off
+if "%rec%"=="01" goto recurs1
+if "%rec%"=="02" goto recurs2
+
+rem echo Looking for bcc
+set rec=01
+set fil=bcc.exe
+testcomp.bat %path%
+goto end
+
+:recurs1
+set rec=
+rem if "%1"=="" ECHO. %fil% not in current directory or path
+if "%1"=="" goto trytcc
+rem echo testing %1\%fil%
+if exist %1.\%fil% goto foundbcc
+shift
+goto recurs1
+
+:trytcc
+rem echo Looking for tcc
+set rec=02
+set fil=tcc.exe
+testcomp.bat %path%
+goto end
+
+:recurs2
+set rec=
+rem if "%1"=="" ECHO. %fil% not in current directory or path
+if "%1"=="" goto end2
+rem echo testing %1\%fil%
+if exist %1.\%fil% goto foundtcc
+shift
+goto recurs2
+
+:foundbcc
+genulib.bat bcc
+goto end
+
+:foundtcc
+genulib.bat tcc
+goto end
+
+:end2
+set fil=
+echo Yer facked!  No suitable compiler found!
+echo If you are using DOSBox, shift doesn't appear to work
+echo correctly, so you may want to validate manually whether
+echo you can find bcc or tcc in your path and then manually
+echo call "genulib.bat bcc" or "genulib.bat tcc"
+
+:end

--- a/SOURCES/src/ulib/ULIB.MAK
+++ b/SOURCES/src/ulib/ULIB.MAK
@@ -8,6 +8,10 @@
 #======================================================================
 #
 # mjs 05/21/92	added data for ulexptab.obj/.c
+# jts 06/30/18  added code for variable ccomp to allow selection of
+#               c compiler (bcc|tcc)
+#               commented out dead code for ulib.xxx and genndx.bat
+#               since extract command is not available
 #
 #======================================================================
 #
@@ -27,19 +31,20 @@
 # required switches:
 #
 # -Dcdir=d:\cutils   (substitute your cutils directory for 'd:\cutils')
+# -Dccomp=bcc        (substitute your compiler bcc or tcc)
 #
 
 #==== implicit rules
 
 .c.obj:
-    bcc -c -I$(cdir) $&.c
+    $(ccomp) -c -I$(cdir) $&.c
     tlib ulib -+$&.obj
-    del ulib.xxx
+#    del ulib.xxx
 
 .asm.obj:
     masm /mx /z $&;
     tlib ulib -+$&.obj
-    del ulib.xxx
+#    del ulib.xxx
 
 #==== the main target
 
@@ -54,8 +59,8 @@ ulib.xxx :	ulbeep.obj   ulstr2v.obj  ulclrbox.obj uldrwbox.obj \
 		ulwalktr.obj ulismos.obj  ulmkpth.obj  ulfsize.obj  \
 		ulwrlbl.obj  ulrdlbl.obj  ulformt.obj  ulqualt.obj
 
-    genndx
-    echo x>ulib.xxx
+#    genndx
+#    echo x>ulib.xxx
 
 #==== c dependencies
 
@@ -103,4 +108,3 @@ ulqualt.obj	: ulqualt.c	$(cdir)\ulib.h
 
 ulsvrswn.obj	: ulsvrswn.asm
 
-

--- a/SOURCES/src/ulib/ULMESSAG.C
+++ b/SOURCES/src/ulib/ULMESSAG.C
@@ -15,13 +15,16 @@
 ======================================================================
 
 mjs 04/01/92	created this module
+jts 06/30/18	added code to allow build under bcc or tcc
 
 =======================================================================
 */
 
 #include <stdlib.h>
 #include <stdio.h>
+#ifdef __BORLANDC__
 #include <malloc.h>
+#endif
 #include <string.h>
 
 #include <asmtypes.h>
@@ -69,7 +72,11 @@ static word ul_storetag(byte *buf, word tag_index) {
       (*s++) = (*t++);
       }
     (*s) = '\0';
+#ifdef __BORLANDC__
     if((msgtags[tag_index] = _fmalloc(sizeof(msgtype))) == NULL) {
+#else
+    if((msgtags[tag_index] = malloc(sizeof(msgtype))) == NULL) {
+#endif
       return(ul_msg_er_memory);
       }
     if((msgtags[tag_index]->tag = strdup(temp)) == NULL) {
@@ -317,4 +324,3 @@ word ul_disp_msg(word x, word y, byte vidattr, byte *srchtag, byte tranflag) {
   return(0);
   }
 
-

--- a/SOURCES/src/ulib/ULOPCLWN.C
+++ b/SOURCES/src/ulib/ULOPCLWN.C
@@ -15,13 +15,16 @@
 ======================================================================
 
 mjs 04/01/92	created this module
+jts 06/30/18	added code to allow build under bcc or tcc
 
 =======================================================================
 */
 
 #include <stdlib.h>
 #include <dos.h>
+#ifdef __BORLANDC__
 #include <malloc.h>
+#endif
 
 #include <asmtypes.h>
 #include "ulib.h"
@@ -41,11 +44,20 @@ wintype ul_open_window(byte xl,byte yt,byte xr,byte yb,byte vattr1,byte vattr2,b
   wintype win;
   word retval;
 
+#ifdef __BORLANDC__
   if((win = (wintype) _fmalloc(sizeof(twin))) == NULL) {
+#else
+  if((win = (wintype) malloc(sizeof(twin))) == NULL) {
+#endif
     return(NULL);
     }
+#ifdef __BORLANDC__
   if((win->winptr = _fmalloc((xr-xl+1)*(yb-yt+1)*2)) == NULL) {
     _ffree(win);
+#else
+  if((win->winptr = malloc((xr-xl+1)*(yb-yt+1)*2)) == NULL) {
+    free(win);
+#endif
     return(NULL);
     }
   win->xl = xl;
@@ -76,8 +88,12 @@ void ul_close_window(wintype win) {
 
   ul_restore_window(win->xl,win->yt,win->xr,win->yb,win->winptr);
   ul_set_cursor(win->x_coord,win->y_coord);
+#ifdef __BORLANDC__
   _ffree(win->winptr);
   _ffree(win);
+#else
+  free(win->winptr);
+  free(win);
+#endif
   }
 
-

--- a/SOURCES/src/ulib/ULREMFIL.C
+++ b/SOURCES/src/ulib/ULREMFIL.C
@@ -15,6 +15,7 @@
 ======================================================================
 
 mjs 04/01/92	created this module
+jts 06/30/18	added code to allow build under bcc or tcc
 
 =======================================================================
 */
@@ -28,6 +29,11 @@ mjs 04/01/92	created this module
 #include <asmtypes.h>
 #include "ulib.h"
 
+#ifndef __BORLANDC__
+#ifndef FA_NORMAL
+#define FA_NORMAL 0x00			// normal file type
+#endif
+#endif
 /*======================================================================
 ;,fs
 ; byte ul_remove_files(byte *filespec, byte search_attr)
@@ -94,4 +100,3 @@ byte ul_remove_files(byte *filespec, byte search_attr) {
     }
   }
 
-

--- a/SOURCES/src/ulib/ULTRDIRL.C
+++ b/SOURCES/src/ulib/ULTRDIRL.C
@@ -15,6 +15,7 @@
 ======================================================================
 
 mjs 12/10/92	created this module
+jts 06/30/18	added code to allow build under bcc or tcc
 
 =======================================================================
 */
@@ -23,7 +24,10 @@ mjs 12/10/92	created this module
 #include <dos.h>
 #include <dir.h>
 #include <string.h>
+
+#ifdef __BORLANDC__
 #include <malloc.h>
+#endif
 
 #include <asmtypes.h>
 #include "ulib.h"
@@ -194,4 +198,3 @@ word ul_trace_dirl(byte *dpbuf, fspc_type *fsptr) {
   *orig_end = 0;
   return(0);
   }
-


### PR DESCRIPTION
Created testcomp.bat file to check for bcc or tcc and call genulib to recreate the ulib library.
Updated files to allow build under either compiler.
Removed dependency on extract command ( Issue #25 )