### PR TITLE
MAKEMOS.BAT: improve PATH handling [fixes #30]

### DIFF
--- a/SOURCES/src/MAKEMOS.BAT
+++ b/SOURCES/src/MAKEMOS.BAT
@@ -2,7 +2,7 @@ rem echo off
 cls
 REM SHIPPING.MOS CONTAINS THE ACTUAL CODE THAT IS SHIPPING.
 REM VERSION 5 UPDATE 6.
-path=c:\dos5.0;c:\borlandc;c:\lib;c:\bin;%PATH%
+path=%PATH%;c:\bin
 set TMP=c:\TMP
 mkdir %TMP%
 cd kernel

--- a/SOURCES/src/build.sh
+++ b/SOURCES/src/build.sh
@@ -12,7 +12,7 @@ fi
 # lowercase ones, they may collide
 rm -f kernel/*.SYS
 rm -f mos5src/*.SYS
-dosemu -td -E MAKEMOS.BAT -U 2 'path=%D\bin;%O'
+dosemu -td -K ./MAKEMOS.BAT -U 2 'path=%D\bin;%O'
 # MOS does not understand files with recent dates so set the old one
 S_DATE="Jan 29 1993"
 touch -d "$S_DATE" mos5src/*.sys


### PR DESCRIPTION
This patch makes the path of MAKEMOS.BAT to be appended
_after_ the original path, that is usually prepared by build.sh.
Also remove the BORLANDC from path, as it is not needed during
build and may fail because of an incompatible make.