### PR TITLE
fix call to mosliman

### DIFF
--- a/SOURCES/src/kernel/MOSDDINT.ASM
+++ b/SOURCES/src/kernel/MOSDDINT.ASM
@@ -877,8 +877,8 @@ mosbd1b:
 mosbd2:
 	pop	es			; address of bdb
 	push	ax			; save error code
-	mov	al,1
-	mov	al,'B'
+	mov	ah,1			; remove memory block
+	mov	al,'B'			; remove BDB entry
 	call	mosliman		; call mosliman
 	pop	ax
 mosbd3:


### PR DESCRIPTION
Add/remove code is passed in AH, not AL.
Spotted by @galazwoj.