### PR TITLE
Fix for 2012 bug!  Original code zeroed al and copied the class

### DIFF
--- a/SOURCES/src/jim/MOSFUTL4.ASM
+++ b/SOURCES/src/jim/MOSFUTL4.ASM
@@ -1252,8 +1252,8 @@ mgx1:
 ; systems will modified the class bits, if not 'A' - 'Z' range
 ; mark file with null class
 
-	xor	al,al			; default to space
-	mov	al,byte ptr [si+dbbbuf+dclass0]
+	xor	ax,ax			; default to space
+	mov	ah,byte ptr [si+dbbbuf+dclass0]
 	cmp	ah,'A'
 	jb	mgfbc1
 	cmp	ah,'Z'
@@ -1981,4 +1981,3 @@ fbdbcx:
 
 ddt	ends
 	end
-

--- a/SOURCES/src/kernel/MOSFUTL4.ASM
+++ b/SOURCES/src/kernel/MOSFUTL4.ASM
@@ -1252,8 +1252,8 @@ mgx1:
 ; systems will modified the class bits, if not 'A' - 'Z' range
 ; mark file with null class
 
-	xor	al,al			; default to space
-	mov	al,byte ptr [si+dbbbuf+dclass0]
+	xor	ax,ax			; default to space
+	mov	ah,byte ptr [si+dbbbuf+dclass0]
 	cmp	ah,'A'
 	jb	mgfbc1
 	cmp	ah,'Z'
@@ -1981,4 +1981,3 @@ fbdbcx:
 
 ddt	ends
 	end
-

--- a/SOURCES/src/mos5src/MOSFUTL4.ASM
+++ b/SOURCES/src/mos5src/MOSFUTL4.ASM
@@ -1275,8 +1275,8 @@ mgx1:
 ; systems will modified the class bits, if not 'A' - 'Z' range
 ; mark file with null class
 
-	xor	al,al			; default to space
-	mov	al,byte ptr [si+dbbbuf+dclass0]
+	xor	ax,ax			; default to space
+	mov	ah,byte ptr [si+dbbbuf+dclass0]
 	cmp	ah,'A'
 	jb	mgfbc1
 	cmp	ah,'Z'
@@ -2005,4 +2005,3 @@ fbdbcx:
 ddt	ends
 	end
 
-


### PR DESCRIPTION
into this register then did comparisons against ah instead of al.
Prior to this instruction, ax had the date in it in directory
entry format.  With the shift in ah for the year going to the 32
as well as the month shifting into the 8 position, this put ah
in range of a class entry, causing any files to become encrypted
and unaccessible afterwards.