### PR TITLE
Increase robustness of dosemu version check

### DIFF
--- a/SOURCES/src/build.sh
+++ b/SOURCES/src/build.sh
@@ -1,10 +1,7 @@
-REV=`dosemu -v | grep Revision | cut -d " " -f 2`
-if [ -z "$REV" ]; then
-    echo "Your dosemu is too old"
-    exit 1
-fi
-if [ $REV -lt 3684 ]; then
-    echo "Your dosemu is too old"
+#!/bin/sh -eu
+REV="$(dosemu --version | grep Revision | cut -d " " -f 2)"
+if [ -z "$REV" ] || [ "$REV" -lt 3684 ]; then
+    echo "At least dosemu2 revision 3684 is required (see dosemu --version)."
     exit 1
 fi
 


### PR DESCRIPTION
* Use --version instead of -v to avoid dosemu1 from starting instead of
  outputting its version. Both dosemu1 and dosemu2 support --version.
  dosemu1 outputs its version to stderr, but grepping for the revision
  in stderr would fail anyways. Do not forward stderr, which has the
  added advantage of printing the not-found-message if dosemu is not
  installed at all.
* Add she-bang
* Use more compact code with only one if-statement