### PR TITLE
remove date work-around

### DIFF
--- a/SOURCES/src/build.sh
+++ b/SOURCES/src/build.sh
@@ -10,6 +10,3 @@ fi
 rm -f kernel/*.SYS
 rm -f mos5src/*.SYS
 dosemu -td -K ./MAKEMOS.BAT -U 2 'path=%D\bin;%O'
-# MOS does not understand files with recent dates so set the old one
-S_DATE="Jan 29 1993"
-touch -d "$S_DATE" mos5src/*.sys


### PR DESCRIPTION
MOS was fixed and now can accept the current dates.