### PR TITLE
build.sh: support newer dosemu syntax

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,4 +6,11 @@ if [ -z "$REV" ] || [ "$REV" -lt 3684 ]; then
     exit 1
 fi
 
-dosemu -td -K SOURCES/src/MAKEMOS.BAT -U 2 'path=%D\bin;%O'
+# dosemu seems to change sytax every few years
+if [ "$REV" -ge 5709 ]; then
+    ARGS="-K .:SOURCES\\src -E MAKEMOS.BAT"
+else
+    ARGS="-K SOURCES/src/MAKEMOS.BAT -U 2"
+fi
+
+dosemu -td -ks $ARGS 'path=%D\bin;%O'


### PR DESCRIPTION
dosemu have removed -U option and deprecated passing the
file names to -K.

Add new syntax support.