### PR TITLE
Docs: Wrap filestruct.md as block for fixed formatting

### DIFF
--- a/BORLANDC/FILESTRUCT.md
+++ b/BORLANDC/FILESTRUCT.md
@@ -1,3 +1,4 @@
+~~~
 .:
 total 104
  0 drwxr-x--- 1 roeland users  2756 Sep  3 13:31 BIN
@@ -898,3 +899,4 @@ total 664
   8 -rw-r----- 1 roeland users   6752 Jul 21 12:37 MSMOUSE.DRV
 128 -rw-r----- 1 roeland users 130816 Jul 21 12:37 PENWIN.DLL
   4 -rw-r----- 1 roeland users    406 Jul 21 12:37 PENWIN.INI
+~~~


### PR DESCRIPTION
Just a small change to fix the display problem that occurred under Github.